### PR TITLE
Added v2 in module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/appknox/bakerstreet
+module github.com/appknox/bakerstreet/v2
 
 go 1.22
 


### PR DESCRIPTION
Post V2+ versions, golang requires modules to have major versions like v2, v3 appended to module names